### PR TITLE
Fixes broken test

### DIFF
--- a/spec/dummy/app/controllers/profiles_controller.rb
+++ b/spec/dummy/app/controllers/profiles_controller.rb
@@ -10,7 +10,7 @@ class ProfilesController < ApplicationController
   end
 
   def name_as_a_integer
-    @profile.name = 1
+    @profile.attributes[:name] = 1
     index
   end
 

--- a/spec/dummy/app/serializers/profile_serializer.rb
+++ b/spec/dummy/app/serializers/profile_serializer.rb
@@ -1,7 +1,3 @@
 class ProfileSerializer < ActiveModel::Serializer
   attributes :name, :description
-
-  def name
-    object.name
-  end
 end

--- a/spec/dummy/app/serializers/profile_serializer.rb
+++ b/spec/dummy/app/serializers/profile_serializer.rb
@@ -1,3 +1,7 @@
 class ProfileSerializer < ActiveModel::Serializer
   attributes :name, :description
+
+  def name
+    object.name
+  end
 end


### PR DESCRIPTION
Without this code, `response.body` is `{"name":"Name 1","description":"Description 1”}`.
With it, it becomes what was expected: `{“name":1,"description":"Description 1”}`

The test won’t pass until name is not a string like the schema says.

[Controller Action](https://github.com/leonelgalan/rspec-active_model_serializers/blob/master/spec/dummy/app/controllers/profiles_controller.rb#L12):
```ruby

  def name_as_a_integer
    @profile = Profile.new(name: 'Name 1', description: 'Description 1') # From before_filter
    @profile.name = 1
    # index
    render json: @profile # index's method body 
  end
```

[Test](https://github.com/leonelgalan/rspec-active_model_serializers/blob/master/spec/lib/rspec/active_model_serializers/matchers/have_valid_schema_spec.rb#L51):
```ruby
  it 'test_simple_json_pointers_that_doesnt_match' do
    get :name_as_a_integer

    expect do
      expect(response).to have_valid_schema.at_path 'simple_json_pointers.json'
    end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
  end
``` 

[Profile](https://github.com/leonelgalan/rspec-active_model_serializers/blob/master/spec/dummy/app/models/profile.rb) is an `ActiveModelSerializers::Model` (0.10.4):
```ruby
class Profile < ActiveModelSerializers::Model
  attr_accessor :name, :description
end
```